### PR TITLE
Fix disabled prop in BottomActions

### DIFF
--- a/components/BottomActions.tsx
+++ b/components/BottomActions.tsx
@@ -32,9 +32,9 @@ export default function BottomActions({
       <Pressable
         style={[
           styles.pranaamButton,
-          selectedCount === 0 && styles.disabledButton,
+          disabled && styles.disabledButton,
         ]}
-        disabled={selectedCount === 0}
+        disabled={disabled}
         onPress={sendPranaam}
       >
         <Text style={styles.pranaamButtonText}>जय श्री राम 🙏</Text>


### PR DESCRIPTION
## Summary
- respect the `disabled` prop when disabling the button in `BottomActions`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*