### PR TITLE
Fix quotes in phone normalization comment

### DIFF
--- a/utils/phone.ts
+++ b/utils/phone.ts
@@ -1,3 +1,3 @@
 export function normalise(phone: string): string {
-    return phone.replace(/\D/g, "");   // keep digits only (“+91 123-456” -> “91123456”)
+    return phone.replace(/\D/g, "");   // keep digits only ("+91 123-456" -> "91123456")
   }


### PR DESCRIPTION
## Summary
- use standard quotes in `utils/phone.ts`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*